### PR TITLE
Image Tagging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,5 +43,8 @@ jobs:
           context: .
           platforms: linux/arm64,linux/amd64
           push: true
-          tags: keytelematics/docker-dotnetcore-runtime-aws:latest
+          tags: |
+            keytelematics/docker-dotnetcore-runtime-aws:latest
+            keytelematics/docker-dotnetcore-runtime-aws:7
+            keytelematics/docker-dotnetcore-runtime-aws:7.0
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Updated the docker image tagging to include latest, the major version of the sdk (7), as well as a major+minor (7.0)